### PR TITLE
Add GIF button to Review changes modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,9 +95,11 @@ var formatGiphyMarkdown = function (giphy, altText) {
 };
 
 var handleGIFButtonClick = function(e) {
-  var textarea = e.target.closest('.js-suggester-container').querySelector('textarea');
+  var textarea = (e.target.closest('.js-suggester-container') || e.target.closest('form')).querySelector('textarea');
   var selection = getSelectionInTextarea(textarea);
   var getGiphy;
+  e.stopPropagation();
+
   if (selection.length && isGiphyId(selection)) {
     getGiphy = getGiphyById(selection);
   } else if (selection.length) {
@@ -127,7 +129,7 @@ var addGiphyToolgroup = function (toolbarEl) {
   giphyButton.setAttribute('data-ga-click', 'Markdown Toolbar, click, giphy');
   toolgroup.appendChild(giphyButton);
   toolbarEl.appendChild(toolgroup);
-  giphyButton.addEventListener('click', handleGIFButtonClick);
+  giphyButton.addEventListener('click', handleGIFButtonClick, true);
 };
 
 var iterateOverToolbars = function (callback) {
@@ -137,10 +139,17 @@ var iterateOverToolbars = function (callback) {
   }
 };
 
+var iterateOverReviews = function (callback) {
+  var tools = document.querySelector('#submit-review > div > form > div.form-actions');
+    callback(tools);
+};
+
 iterateOverToolbars(addGiphyToolgroup);
+iterateOverReviews(addGiphyToolgroup);
 
 var observer = new MutationObserver(function (mutations) {
   iterateOverToolbars(addGiphyToolgroup);
+  iterateOverReviews(addGiphyToolgroup);
 });
 
 var config = { attributes: true, childList: true, characterData: true };


### PR DESCRIPTION
Hello @stevenlundy! In our organisation there a folks using your extension when we approval a PR, It's very funny! But now we are using the new feature of Github to Review Changes, so it would be nice to have the GIF button when we are doing the Review Changes.

The changes that I made are simple, just coping the `iterateOverToolbars` to find where the button should be, then added to the `MutationObserver`. 

In the `handleGIFButtonClick` behaviour verify which target it is to find the corresponding textarea  and finally `e.stopPropagation();` to avoid close the modal when there is a onClick event.

Let me know what do you think about it.

Thanks!